### PR TITLE
WIP systemd-style socket activation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -948,7 +948,7 @@ int main(void) { if (NSVersionOfRunTimeLibrary("System") >= (60 << 16))
 			fi
 		],
 	)
-
+	AC_DEFINE([USE_SYSTEMD_SOCKET_ACTIVATION], [1], [Attempt systemd-style socket activation in sshd])
 	AC_DEFINE([SYSTEMD_NOTIFY], [1], [Have sshd notify systemd on start/reload])
 	inet6_default_4in6=yes
 	case `uname -r` in

--- a/platform.h
+++ b/platform.h
@@ -33,6 +33,7 @@ char *platform_krb5_get_principal_name(const char *);
 int platform_locked_account(struct passwd *);
 int platform_sys_dir_uid(uid_t);
 void platform_disable_tracing(int);
+int platform_socket_activation(int **, int *, int);
 
 /* in platform-pledge.c */
 void platform_pledge_agent(void);

--- a/sshd-auth.c
+++ b/sshd-auth.c
@@ -488,13 +488,16 @@ main(int ac, char **av)
 
 	/* Parse command-line arguments. */
 	while ((opt = getopt(ac, av,
-	    "C:E:b:c:f:g:h:k:o:p:u:46DGQRTdeiqrtV")) != -1) {
+	    "C:E:b:c:f:g:h:k:o:p:u:46ADGQRTdeiqrtV")) != -1) {
 		switch (opt) {
 		case '4':
 			options.address_family = AF_INET;
 			break;
 		case '6':
 			options.address_family = AF_INET6;
+			break;
+		case 'A':
+			/* ignore */
 			break;
 		case 'f':
 			config_file_name = optarg;

--- a/sshd-session.c
+++ b/sshd-session.c
@@ -879,13 +879,16 @@ main(int ac, char **av)
 
 	/* Parse command-line arguments. */
 	while ((opt = getopt(ac, av,
-	    "C:E:b:c:f:g:h:k:o:p:u:46DGQRTdeiqrtV")) != -1) {
+	    "C:E:b:c:f:g:h:k:o:p:u:46ADGQRTdeiqrtV")) != -1) {
 		switch (opt) {
 		case '4':
 			options.address_family = AF_INET;
 			break;
 		case '6':
 			options.address_family = AF_INET6;
+			break;
+		case 'A':
+			/* ignore */
 			break;
 		case 'f':
 			config_file_name = optarg;

--- a/sshd.8
+++ b/sshd.8
@@ -43,7 +43,7 @@
 .Sh SYNOPSIS
 .Nm sshd
 .Bk -words
-.Op Fl 46DdeGiqTtV
+.Op Fl 46ADdeGiqTtV
 .Op Fl C Ar connection_spec
 .Op Fl c Ar host_certificate_file
 .Op Fl E Ar log_file
@@ -93,6 +93,16 @@ to use IPv4 addresses only.
 Forces
 .Nm
 to use IPv6 addresses only.
+.It Fl A
+Instruct
+.Nm
+to obtain its listening sockets from a parent supervising process via socket
+activation.
+The default behaviour is for
+.Nm
+to listen on the addresses specified by the
+.Cm ListenAddress
+directives in its configuration or, if none are specified, the wildcard address.
 .It Fl C Ar connection_spec
 Specify the connection parameters to use for the
 .Fl T


### PR DESCRIPTION
Pass the `-A` option to sshd(8) to use this. Not compatible with inetd mode (`-i`) and probably doesn't do what you want in debug mode either.

Example to test:

```
sudo systemd-socket-activate -l 22222 -l22223 -l22224 $PWD/sshd -DeoLoglevel=debug3 \
    -osshdSessionPath=$PWD/sshd-session -osshdAuthPath=$PWD/sshd-auth -A
```