### PR TITLE
Add a CONFIG_H_INCLUDED guard to config.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,8 @@ if test -z "$AR" ; then
 	AC_MSG_ERROR([*** 'ar' missing, please install or fix your \$PATH ***])
 fi
 
+AC_DEFINE(CONFIG_H_INCLUDED, 1, [config.h has been included]) ]
+
 AC_PATH_PROG([PATH_PASSWD_PROG], [passwd])
 if test ! -z "$PATH_PASSWD_PROG" ; then
 	AC_DEFINE_UNQUOTED([_PATH_PASSWD_PROG], ["$PATH_PASSWD_PROG"],

--- a/includes.h
+++ b/includes.h
@@ -16,7 +16,9 @@
 #ifndef INCLUDES_H
 #define INCLUDES_H
 
+#ifndef CONFIG_H_INCLUDED
 #include "config.h"
+#endif
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE /* activate extra prototypes for glibc */


### PR DESCRIPTION
This allows third-party users of portable OpenSSH code (e.g. HIBA) to block inclusion of config.h, but still include includes.h if they need it.