### PR TITLE
Adjust priority order of certificates used by the client

### DIFF
--- a/regress/Makefile
+++ b/regress/Makefile
@@ -87,6 +87,7 @@ LTESTS= 	connect \
 		kextype \
 		cert-hostkey \
 		cert-userkey \
+		pubkey-priority \
 		host-expand \
 		keys-command \
 		forward-control \

--- a/regress/agent.sh
+++ b/regress/agent.sh
@@ -64,6 +64,7 @@ done
 # Remove explicit identity directives from ssh_proxy
 mv $OBJ/ssh_proxy $OBJ/ssh_proxy_bak
 grep -vi identityfile $OBJ/ssh_proxy_bak > $OBJ/ssh_proxy
+echo "MaxAuthTries 64" >> $OBJ/sshd_proxy
 
 ${SSHADD} -l > /dev/null 2>&1
 r=$?

--- a/regress/pubkey-priority.sh
+++ b/regress/pubkey-priority.sh
@@ -1,0 +1,120 @@
+#	$OpenBSD$
+#	Placed in the Public Domain.
+
+tid="public key priority and ordering"
+
+rm -f $OBJ/ca_key* $OBJ/explicit_agent* $OBJ/explicit_fs* \
+	$OBJ/agent_sk_notouch* $OBJ/agent_sk_verify* $OBJ/agent_normal_cert* \
+	$OBJ/agent_plain* $OBJ/id_ed25519*
+
+trace "start agent"
+eval `${SSHAGENT} ${EXTRA_AGENT_ARGS} -s` >/dev/null
+r=$?
+if [ $r -ne 0 ]; then
+	fatal "could not start ssh-agent: exit code $r"
+fi
+
+# Generate CA
+${SSHKEYGEN} -q -N '' -t ed25519 -f $OBJ/ca_key || fatal "ca keygen failed"
+
+# 1. Explicit filesystem key
+${SSHKEYGEN} -q -N '' -t ed25519 -C explicit_fs -f $OBJ/explicit_fs || fatal "keygen explicit_fs failed"
+
+# 2. Explicit agent key
+${SSHKEYGEN} -q -N '' -t ed25519 -C explicit_agent -f $OBJ/explicit_agent || fatal "keygen explicit_agent failed"
+
+# 3. Implicit filesystem key (default id_ed25519)
+${SSHKEYGEN} -q -N '' -t ed25519 -C implicit_fs -f $OBJ/id_ed25519 || fatal "keygen implicit failed"
+
+# 4. Agent plain key
+${SSHKEYGEN} -q -N '' -t ed25519 -C agent_plain -f $OBJ/agent_plain || fatal "keygen agent_plain failed"
+
+# 5. Agent normal cert
+${SSHKEYGEN} -q -N '' -t ed25519 -C agent_normal_cert -f $OBJ/agent_normal_cert || fatal "keygen agent_normal_cert failed"
+${SSHKEYGEN} -qs $OBJ/ca_key -I "normal cert" -n estragon $OBJ/agent_normal_cert.pub || fatal "ca sign normal failed"
+
+# 6. Agent SK verify-required cert
+${SSHKEYGEN} -q -N '' -t ed25519-sk -C agent_sk_verify -f $OBJ/agent_sk_verify || fatal "keygen agent_sk_verify failed"
+${SSHKEYGEN} -qs $OBJ/ca_key -I "verify cert" -n estragon -O verify-required $OBJ/agent_sk_verify.pub || fatal "ca sign verify failed"
+
+# 7. Agent SK no-touch-required cert
+${SSHKEYGEN} -q -N '' -t ed25519-sk -C agent_sk_notouch -f $OBJ/agent_sk_notouch || fatal "keygen agent_sk_notouch failed"
+${SSHKEYGEN} -qs $OBJ/ca_key -I "notouch cert" -n estragon -O no-touch-required $OBJ/agent_sk_notouch.pub || fatal "ca sign notouch failed"
+
+# Load agent keys in reverse order of expected priority
+${SSHADD} $OBJ/agent_plain >/dev/null 2>&1 || fatal "ssh-add agent_plain failed"
+${SSHADD} $OBJ/agent_normal_cert >/dev/null 2>&1 || fatal "ssh-add agent_normal_cert failed"
+${SSHADD} $OBJ/agent_sk_verify >/dev/null 2>&1 || fatal "ssh-add agent_sk_verify failed"
+${SSHADD} $OBJ/agent_sk_notouch >/dev/null 2>&1 || fatal "ssh-add agent_sk_notouch failed"
+${SSHADD} $OBJ/explicit_agent >/dev/null 2>&1 || fatal "ssh-add explicit_agent failed"
+
+cat > $OBJ/ssh_config_prio <<EOF
+Host test
+	HostName 127.0.0.1
+	IdentityFile $OBJ/explicit_agent
+	IdentityFile $OBJ/explicit_fs
+EOF
+
+trace "verify key priority order"
+${SSH} -F $OBJ/ssh_config_prio -Z test > $OBJ/prio.out 2>&1 || fatal "ssh -Z failed"
+
+cat > $OBJ/prio.expected <<EOF
+$OBJ/explicit_agent ED25519
+agent_sk_notouch ED25519-SK-CERT
+agent_normal_cert ED25519-CERT
+agent_sk_verify ED25519-SK-CERT
+agent_plain ED25519
+agent_normal_cert ED25519
+agent_sk_verify ED25519-SK
+agent_sk_notouch ED25519-SK
+$OBJ/explicit_fs ED25519
+EOF
+
+awk '{print $1 " " $2}' < $OBJ/prio.out > $OBJ/prio.got
+if ! cmp $OBJ/prio.expected $OBJ/prio.got >/dev/null 2>&1; then
+	diff -u $OBJ/prio.expected $OBJ/prio.got
+	fail "unexpected public key ordering"
+fi
+
+trace "verify IdentitiesOnly ordering"
+${SSH} -F $OBJ/ssh_config_prio -oIdentitiesOnly=yes -Z test > $OBJ/prio_identities.out 2>&1 || fatal "ssh -Z IdentitiesOnly failed"
+
+cat > $OBJ/prio_identities.expected <<EOF
+$OBJ/explicit_agent ED25519
+$OBJ/explicit_fs ED25519
+EOF
+
+awk '{print $1 " " $2}' < $OBJ/prio_identities.out > $OBJ/prio_identities.got
+if ! cmp $OBJ/prio_identities.expected $OBJ/prio_identities.got >/dev/null 2>&1; then
+	diff -u $OBJ/prio_identities.expected $OBJ/prio_identities.got
+	fail "unexpected IdentitiesOnly public key ordering"
+fi
+
+trace "verify implicit key ordering"
+HOME=$OBJ ${SSH} -F /dev/null -Z test > $OBJ/prio_implicit.out 2>&1 || fatal "ssh -Z implicit failed"
+
+cat > $OBJ/prio_implicit.expected <<EOF
+agent_sk_notouch ED25519-SK-CERT
+agent_normal_cert ED25519-CERT
+agent_sk_verify ED25519-SK-CERT
+agent_plain ED25519
+agent_normal_cert ED25519
+agent_sk_verify ED25519-SK
+agent_sk_notouch ED25519-SK
+explicit_agent ED25519
+$HOME/.ssh/id_rsa 
+$HOME/.ssh/id_ecdsa 
+$HOME/.ssh/id_ecdsa_sk ECDSA-SK
+$HOME/.ssh/id_ed25519 ED25519
+$HOME/.ssh/id_ed25519_sk 
+$HOME/.ssh/id_mldsa44_ed25519 
+EOF
+
+awk '{print $1 " " $2}' <  $OBJ/prio_implicit.out > $OBJ/prio_implicit.got
+if ! cmp $OBJ/prio_implicit.expected $OBJ/prio_implicit.got >/dev/null 2>&1; then
+	diff -u $OBJ/prio_implicit.expected $OBJ/prio_implicit.got
+	fail "unexpected implicit public key ordering"
+fi
+
+trace "kill agent"
+${SSHAGENT} -k >/dev/null

--- a/ssh.1
+++ b/ssh.1
@@ -42,7 +42,7 @@
 .Nd OpenSSH remote login client
 .Sh SYNOPSIS
 .Nm ssh
-.Op Fl 46AaCfGgKkMNnqsTtVvXxYy
+.Op Fl 46AaCfGgKkMNnqsTtVvZXxYy
 .Op Fl B Ar bind_interface
 .Op Fl b Ar bind_address
 .Op Fl c Ar cipher_spec
@@ -781,6 +781,10 @@ Send log information using the
 .Xr syslog 3
 system module.
 By default this information is sent to stderr.
+.Pp
+.It Fl Z
+Dump the public keys that would be attempted for authentication to the specified
+destination in preferred order and exit.
 .El
 .Pp
 .Nm

--- a/ssh.c
+++ b/ssh.c
@@ -168,7 +168,7 @@ static void
 usage(void)
 {
 	fprintf(stderr,
-"usage: ssh [-46AaCfGgKkMNnqsTtVvXxYy] [-B bind_interface] [-b bind_address]\n"
+"usage: ssh [-46AaCfGgKkMNnqsTtVvZXxYy] [-B bind_interface] [-b bind_address]\n"
 "           [-c cipher_spec] [-D [bind_address:]port] [-E log_file]\n"
 "           [-e escape_char] [-F configfile] [-I pkcs11] [-i identity_file]\n"
 "           [-J destination] [-L address] [-l login_name] [-m mac_spec]\n"
@@ -621,7 +621,7 @@ main(int ac, char **av)
 {
 	struct ssh *ssh = NULL;
 	int i, r, opt, exit_status, use_syslog, direct, timeout_ms;
-	int was_addr, config_test = 0, opt_terminated = 0, want_final_pass = 0;
+	int was_addr, config_test = 0, dump_pubkeys = 0, opt_terminated = 0, want_final_pass = 0;
 	int user_on_commandline = 0, user_was_default = 0, user_expanded = 0;
 	char *p, *cp, *line, *argv0, *logfile, *args;
 	char cname[NI_MAXHOST], thishost[NI_MAXHOST];
@@ -701,7 +701,7 @@ main(int ac, char **av)
 
  again:
 	while ((opt = getopt(ac, av, "1246ab:c:e:fgi:kl:m:no:p:qstvx"
-	    "AB:CD:E:F:GI:J:KL:MNO:P:Q:R:S:TVw:W:XYy")) != -1) { /* HUZdhjruz */
+	    "AB:CD:E:F:GI:J:KL:MNO:P:Q:R:S:TVw:W:XYZy")) != -1) { /* HUdhjruz */
 		switch (opt) {
 		case '1':
 			fatal("SSH protocol v.1 is no longer supported");
@@ -740,6 +740,9 @@ main(int ac, char **av)
 		case 'Y':
 			options.forward_x11 = 1;
 			options.forward_x11_trusted = 1;
+			break;
+		case 'Z':
+			dump_pubkeys = 1;
 			break;
 		case 'g':
 			options.fwd_opts.gateway_ports = 1;
@@ -1638,6 +1641,38 @@ main(int ac, char **av)
 		}
 	}
 
+	/* load options.identity_files */
+	load_public_identity_files(cinfo);
+
+	/* optionally set the SSH_AUTHSOCKET_ENV_NAME variable */
+	if (options.identity_agent &&
+	    strcmp(options.identity_agent, SSH_AUTHSOCKET_ENV_NAME) != 0) {
+		if (strcmp(options.identity_agent, "none") == 0) {
+			unsetenv(SSH_AUTHSOCKET_ENV_NAME);
+		} else {
+			cp = options.identity_agent;
+			/* legacy (limited) format */
+			if (cp[0] == '$' && cp[1] != '{') {
+				if (!valid_env_name(cp + 1)) {
+					fatal("Invalid IdentityAgent "
+					    "environment variable name %s", cp);
+				}
+				if ((p = getenv(cp + 1)) == NULL)
+					unsetenv(SSH_AUTHSOCKET_ENV_NAME);
+				else
+					setenv(SSH_AUTHSOCKET_ENV_NAME, p, 1);
+			} else {
+				/* identity_agent specifies a path directly */
+				setenv(SSH_AUTHSOCKET_ENV_NAME, cp, 1);
+			}
+		}
+	}
+
+	if (dump_pubkeys) {
+		pubkey_dump(ssh);
+		exit(0);
+	}
+
 	/*
 	 * If hostname canonicalisation was not enabled, then we may not
 	 * have yet resolved the hostname. Do so now.
@@ -1729,33 +1764,6 @@ main(int ac, char **av)
 			if (loaded == 0)
 				debug("HostbasedAuthentication enabled but no "
 				   "local public host keys could be loaded.");
-		}
-	}
-
-	/* load options.identity_files */
-	load_public_identity_files(cinfo);
-
-	/* optionally set the SSH_AUTHSOCKET_ENV_NAME variable */
-	if (options.identity_agent &&
-	    strcmp(options.identity_agent, SSH_AUTHSOCKET_ENV_NAME) != 0) {
-		if (strcmp(options.identity_agent, "none") == 0) {
-			unsetenv(SSH_AUTHSOCKET_ENV_NAME);
-		} else {
-			cp = options.identity_agent;
-			/* legacy (limited) format */
-			if (cp[0] == '$' && cp[1] != '{') {
-				if (!valid_env_name(cp + 1)) {
-					fatal("Invalid IdentityAgent "
-					    "environment variable name %s", cp);
-				}
-				if ((p = getenv(cp + 1)) == NULL)
-					unsetenv(SSH_AUTHSOCKET_ENV_NAME);
-				else
-					setenv(SSH_AUTHSOCKET_ENV_NAME, p, 1);
-			} else {
-				/* identity_agent specifies a path directly */
-				setenv(SSH_AUTHSOCKET_ENV_NAME, cp, 1);
-			}
 		}
 	}
 

--- a/sshconnect.h
+++ b/sshconnect.h
@@ -91,6 +91,8 @@ void	 ssh_kex2(struct ssh *ssh, char *, struct sockaddr_storage *, u_short,
 void	 ssh_userauth2(struct ssh *ssh, const char *, const char *,
     char *, Sensitive *);
 
+void	 pubkey_dump(struct ssh *);
+
 int	 ssh_local_cmd(const char *);
 
 void	 maybe_add_key_to_agent(const char *, struct sshkey *,

--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -1670,18 +1670,108 @@ get_agent_identities(struct ssh *ssh, int *agent_fdp,
 }
 
 /*
+ * Returns nonzero if the certificate extensions/critical-options section
+ * has the specified option present, zero otherwise.
+ */
+static int
+cert_has_option(struct sshbuf *oblob, const char *target)
+{
+	struct sshbuf *c = NULL, *data = NULL;
+	char *name = NULL;
+	int r, found = 0;
+
+	if (oblob == NULL || (c = sshbuf_fromb(oblob)) == NULL)
+		return 0;
+	while (sshbuf_len(c) > 0) {
+		sshbuf_free(data);
+		data = NULL;
+		free(name);
+		name = NULL;
+		if ((r = sshbuf_get_cstring(c, &name, NULL)) != 0 ||
+		    (r = sshbuf_froms(c, &data)) != 0)
+			break;
+		if (strcmp(name, target) == 0) {
+			found = 1;
+			break;
+		}
+	}
+	sshbuf_free(data);
+	free(name);
+	sshbuf_free(c);
+	return found;
+}
+
+/*
+ * Returns an integer describing the priority of the identity
+ * within its group. Lower numbers are higher priority.
+ */
+#define MAX_ID_PRIORITY 3
+static int
+identity_prioritise(struct identity *id)
+{
+	if (id == NULL || id->key == NULL)
+		return 3;
+	if (!sshkey_is_cert(id->key) || id->key->cert == NULL)
+		return 3;
+	if (sshkey_is_sk(id->key) &&
+	    cert_has_option(id->key->cert->critical, "verify-required"))
+		return 2;
+	if (sshkey_is_sk(id->key) &&
+	    cert_has_option(id->key->cert->extensions, "no-touch-required"))
+		return 0;
+	return 1;
+}
+
+static void
+order_identities_by_prio(struct idlist *list)
+{
+	struct idlist prio[MAX_ID_PRIORITY + 1], sorted;
+	struct identity *id, *tmp, *dummy;
+	int p;
+
+	for (p = 0; p <= MAX_ID_PRIORITY; p++)
+		TAILQ_INIT(&prio[p]);
+	TAILQ_INIT(&sorted);
+
+	TAILQ_FOREACH_SAFE(id, list, next, tmp) {
+		if (id->userprovided)
+			continue;
+		dummy = xcalloc(1, sizeof(*dummy));
+		dummy->userprovided = -1;
+		TAILQ_INSERT_BEFORE(id, dummy, next);
+		TAILQ_REMOVE(list, id, next);
+		p = identity_prioritise(id);
+		if (p < 0 || p > MAX_ID_PRIORITY)
+			fatal_f("internal error: bad priority");
+		TAILQ_INSERT_TAIL(&prio[p], id, next);
+	}
+	for (p = 0; p <= MAX_ID_PRIORITY; p++)
+		TAILQ_CONCAT(&sorted, &prio[p], next);
+
+	TAILQ_FOREACH_SAFE(id, list, next, tmp) {
+		if (id->userprovided != -1)
+			continue;
+		struct identity *s = TAILQ_FIRST(&sorted);
+		TAILQ_REMOVE(&sorted, s, next);
+		TAILQ_INSERT_BEFORE(id, s, next);
+		TAILQ_REMOVE(list, id, next);
+		free(id);
+	}
+}
+
+/*
  * try keys in the following order:
  *	1. certificates listed in the config file
- *	2. other input certificates
- *	3. agent keys that are found in the config file
- *	4. other agent keys
+ *	2. agent keys that are found in the config file
+ *	3. other agent keys
+ *	4. PKCS#11 keys that are found in the config file
  *	5. keys that are only listed in the config file
  */
 static void
 pubkey_prepare(struct ssh *ssh, Authctxt *authctxt)
 {
 	struct identity *id, *id2, *tmp;
-	struct idlist agent, files, *preferred;
+	struct idlist agent, files, certs, agent_keys, *preferred;
 	struct sshkey *key;
 	int disallowed, agent_fd = -1, i, r, found;
 	size_t j;
@@ -1690,6 +1780,8 @@ pubkey_prepare(struct ssh *ssh, Authctxt *authctxt)
 
 	TAILQ_INIT(&agent);	/* keys from the agent */
 	TAILQ_INIT(&files);	/* keys from the config file */
+	TAILQ_INIT(&certs);	/* certificates specified by user */
+	TAILQ_INIT(&agent_keys); /* keys supported by the agent */
 	preferred = &authctxt->keys;
 	TAILQ_INIT(preferred);	/* preferred order of keys */
 
@@ -1716,6 +1808,7 @@ pubkey_prepare(struct ssh *ssh, Authctxt *authctxt)
 		id->userprovided = options.identity_file_userprovided[i];
 		TAILQ_INSERT_TAIL(&files, id, next);
 	}
+
 	/* list of certificates specified by user */
 	for (i = 0; i < options.num_certificate_files; i++) {
 		key = options.certificates[i];
@@ -1737,8 +1830,11 @@ pubkey_prepare(struct ssh *ssh, Authctxt *authctxt)
 		id->key = key;
 		id->filename = xstrdup(options.certificate_files[i]);
 		id->userprovided = options.certificate_file_userprovided[i];
-		TAILQ_INSERT_TAIL(preferred, id, next);
+		TAILQ_INSERT_TAIL(&certs, id, next);
 	}
+	order_identities_by_prio(&certs);
+	TAILQ_CONCAT(preferred, &certs, next);
+
 	/* list of keys supported by the agent */
 	if ((r = get_agent_identities(ssh, &agent_fd, &idlist)) == 0) {
 		for (j = 0; j < idlist->nkeys; j++) {
@@ -1756,7 +1852,7 @@ pubkey_prepare(struct ssh *ssh, Authctxt *authctxt)
 				 */
 				if (sshkey_equal(idlist->keys[j], id->key)) {
 					TAILQ_REMOVE(&files, id, next);
-					TAILQ_INSERT_TAIL(preferred, id, next);
+					TAILQ_INSERT_TAIL(&agent_keys, id, next);
 					id->agent_fd = agent_fd;
 					found = 1;
 					break;
@@ -1774,8 +1870,10 @@ pubkey_prepare(struct ssh *ssh, Authctxt *authctxt)
 			}
 		}
 		ssh_free_identitylist(idlist);
+		TAILQ_CONCAT(&agent_keys, &agent, next);
+		order_identities_by_prio(&agent_keys);
 		/* append remaining agent keys */
-		TAILQ_CONCAT(preferred, &agent, next);
+		TAILQ_CONCAT(preferred, &agent_keys, next);
 		authctxt->agent_fd = agent_fd;
 	}
 	/* Prefer PKCS11 keys that are explicitly listed */
@@ -1800,6 +1898,7 @@ pubkey_prepare(struct ssh *ssh, Authctxt *authctxt)
 			freezero(id, sizeof(*id));
 		}
 	}
+	order_identities_by_prio(&files);
 	/* append remaining keys from the config file */
 	TAILQ_CONCAT(preferred, &files, next);
 	/* finally, filter by PubkeyAcceptedAlgorithms */

--- a/sshconnect2.c
+++ b/sshconnect2.c
@@ -1649,11 +1649,13 @@ get_agent_identities(struct ssh *ssh, int *agent_fdp,
 			debug_fr(r, "ssh_get_authentication_socket");
 		return r;
 	}
-	if ((r = ssh_agent_bind_hostkey(agent_fd, ssh->kex->initial_hostkey,
-	    ssh->kex->session_id, ssh->kex->initial_sig, 0)) == 0)
-		debug_f("bound agent to hostkey");
-	else
-		debug2_fr(r, "ssh_agent_bind_hostkey");
+	if (ssh != NULL && ssh->kex != NULL) {
+		if ((r = ssh_agent_bind_hostkey(agent_fd, ssh->kex->initial_hostkey,
+		    ssh->kex->session_id, ssh->kex->initial_sig, 0)) == 0)
+			debug_f("bound agent to hostkey");
+		else
+			debug2_fr(r, "ssh_agent_bind_hostkey");
+	}
 
 	if ((r = ssh_fetch_identitylist(agent_fd, &idlist)) != 0) {
 		debug_fr(r, "ssh_fetch_identitylist");
@@ -1811,7 +1813,8 @@ pubkey_prepare(struct ssh *ssh, Authctxt *authctxt)
 			    "not in PubkeyAcceptedAlgorithms",
 			    sshkey_ssh_name(id->key), id->filename);
 			disallowed = 1;
-		} else if (ssh->kex->server_sig_algs != NULL &&
+		} else if (ssh != NULL && ssh->kex != NULL &&
+		    ssh->kex->server_sig_algs != NULL &&
 		    (cp = key_sig_algorithm(ssh, id->key)) == NULL) {
 			debug("Skipping %s key %s - corresponding algorithm "
 			    "not supported by server",
@@ -1853,6 +1856,27 @@ pubkey_cleanup(struct ssh *ssh)
 		free(id->filename);
 		free(id);
 	}
+}
+
+void
+pubkey_dump(struct ssh *ssh)
+{
+	Authctxt authctxt;
+	Identity *id;
+	char *ident;
+
+	memset(&authctxt, 0, sizeof(authctxt));
+	authctxt.agent_fd = -1;
+	ssh->authctxt = &authctxt;
+
+	pubkey_prepare(ssh, &authctxt);
+	TAILQ_FOREACH(id, &authctxt.keys, next) {
+		ident = format_identity(id);
+		fprintf(stdout, "%s\n", ident);
+		free(ident);
+	}
+	pubkey_cleanup(ssh);
+	ssh->authctxt = NULL;
 }
 
 static void


### PR DESCRIPTION
This makes the client order FIDO certificates a little differently, by attempting certificates with the `no-touch-required` option first, followed by other certificates and FIDO certificates with `verify-required` last.

The intent here is that credentials that incur less user friction are attempted before ones that require more (either touch, PIN or biometric).

WIP
TODO: same treatment for on-disk keys where the private key is loaded and we have access to sk_flags to check UP/UV